### PR TITLE
fix base version check

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -29,8 +29,8 @@ jobs:
         with:
           #base-image: ${{ env.BASE_IMAGE }}:${{ env.IMAGE_TAG }}
           #image: ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
-          base-image: nginx:alpine
-          image: pruh/nginx-with-modules:alpine
+          base-image: nginx:1.23.3-alpine
+          image: pruh/nginx-with-modules:1.23.3-alpine
           verbose: true
 
       # only execute subsequent steps if an update is actually NEEDED.

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,6 +3,11 @@ name: Docker
 on:
   schedule:
     - cron: '0 1 * * *'
+  
+  pull_request:
+    branches: [ "master" ]
+  push:
+    branches: [ "debug_rebuilds" ]
     
 env:
   BASE_IMAGE: library/nginx
@@ -41,14 +46,16 @@ jobs:
                 sed 's/-alpine//' |
                 sort --version-sort |
                 tail -n 1) >> $GITHUB_OUTPUT
-        if: steps.check.outputs.needs-updating == 'true'
+        if: false
+        #if: steps.check.outputs.needs-updating == 'true'
 
       - name: Login to DockerHub
         uses: docker/login-action@v2.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-        if: steps.check.outputs.needs-updating == 'true'
+        if: false
+        #if: steps.check.outputs.needs-updating == 'true'
 
       - name: Build and push Docker images
         uses: docker/build-push-action@v3.2.0
@@ -59,4 +66,5 @@ jobs:
             ${{ env.IMAGE_NAME }}:latest
             ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
             ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.nginx_version }}-${{ env.IMAGE_TAG }}
-        if: steps.check.outputs.needs-updating == 'true'
+        if: false
+        #if: steps.check.outputs.needs-updating == 'true'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,8 +6,6 @@ on:
   
   pull_request:
     branches: [ "master" ]
-  push:
-    branches: [ "debug_rebuilds" ]
     
 env:
   BASE_IMAGE: library/nginx
@@ -26,13 +24,9 @@ jobs:
       - name: Check if update available
         id: check
         uses: lucacome/docker-image-update-checker@v1.1.1
-#        uses: giggio/docker-image-update-checker@v2.0.1
         with:
-          #base-image: ${{ env.BASE_IMAGE }}:${{ env.IMAGE_TAG }}
-          #image: ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
-          base-image: library/nginx:alpine
-          image: pruh/nginx-with-modules:alpine
-#          verbose: true
+          base-image: ${{ env.BASE_IMAGE }}:${{ env.IMAGE_TAG }}
+          image: ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
 
       # only execute subsequent steps if an update is actually NEEDED.
       # unfortunately we need to add an if-condition to all steps now
@@ -49,16 +43,14 @@ jobs:
                 sed 's/-alpine//' |
                 sort --version-sort |
                 tail -n 1) >> $GITHUB_OUTPUT
-        if: false
-        #if: steps.check.outputs.needs-updating == 'true'
+        if: steps.check.outputs.needs-updating == 'true'
 
       - name: Login to DockerHub
         uses: docker/login-action@v2.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-        if: false
-        #if: steps.check.outputs.needs-updating == 'true'
+        if: steps.check.outputs.needs-updating == 'true'
 
       - name: Build and push Docker images
         uses: docker/build-push-action@v3.2.0
@@ -69,5 +61,4 @@ jobs:
             ${{ env.IMAGE_NAME }}:latest
             ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
             ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.nginx_version }}-${{ env.IMAGE_TAG }}
-        if: false
-        #if: steps.check.outputs.needs-updating == 'true'
+        if: false #steps.check.outputs.needs-updating == 'true'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -61,4 +61,4 @@ jobs:
             ${{ env.IMAGE_NAME }}:latest
             ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
             ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.nginx_version }}-${{ env.IMAGE_TAG }}
-        if: false #steps.check.outputs.needs-updating == 'true'
+        if: steps.check.outputs.needs-updating == 'true'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,9 +30,9 @@ jobs:
         with:
           #base-image: ${{ env.BASE_IMAGE }}:${{ env.IMAGE_TAG }}
           #image: ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
-          base-image: nginx:1.23.3-alpine
-          image: pruh/nginx-with-modules:1.23.3-alpine
-          verbose: true
+          base-image: library/nginx:alpine
+          image: pruh/nginx-with-modules:alpine
+#          verbose: true
 
       # only execute subsequent steps if an update is actually NEEDED.
       # unfortunately we need to add an if-condition to all steps now

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Check if update available
         id: check
-        uses: lucacome/docker-image-update-checker@v1
+        uses: lucacome/docker-image-update-checker@v1.1.1
 #        uses: giggio/docker-image-update-checker@v2.0.1
         with:
           #base-image: ${{ env.BASE_IMAGE }}:${{ env.IMAGE_TAG }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,7 +25,8 @@ jobs:
 
       - name: Check if update available
         id: check
-        uses: giggio/docker-image-update-checker@v2.0.1
+        uses: lucacome/docker-image-update-checker@v1
+#        uses: giggio/docker-image-update-checker@v2.0.1
         with:
           #base-image: ${{ env.BASE_IMAGE }}:${{ env.IMAGE_TAG }}
           #image: ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -27,8 +27,10 @@ jobs:
         id: check
         uses: giggio/docker-image-update-checker@v2.0.1
         with:
-          base-image: ${{ env.BASE_IMAGE }}:${{ env.IMAGE_TAG }}
-          image: ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+          #base-image: ${{ env.BASE_IMAGE }}:${{ env.IMAGE_TAG }}
+          #image: ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+          base-image: nginx:alpine
+          image: pruh/nginx-with-modules:alpine
           verbose: true
 
       # only execute subsequent steps if an update is actually NEEDED.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.23.3-alpine AS builder
+FROM nginx:alpine AS builder
 
 # nginx:alpine contains NGINX_VERSION environment variable, like so:
 # ENV NGINX_VERSION 1.23.3
@@ -42,7 +42,7 @@ RUN CONFARGS=$(nginx -V 2>&1 | sed -n -e 's/^.*arguments: //p') \
   ./configure --with-compat $CONFARGS --add-dynamic-module=$NGX_DEVEL_KIT_DIR --add-dynamic-module=$SET_MISC_DIR && \
   make modules
 
-FROM nginx:1.23.3-alpine
+FROM nginx:alpine
 
 # Extract the dynamic modules from the builder image
 COPY --from=builder /usr/src/nginx/nginx-${NGINX_VERSION}/objs/*_module.so /etc/nginx/modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:alpine AS builder
+FROM nginx:1.23.3-alpine AS builder
 
 # nginx:alpine contains NGINX_VERSION environment variable, like so:
 # ENV NGINX_VERSION 1.23.3
@@ -42,7 +42,7 @@ RUN CONFARGS=$(nginx -V 2>&1 | sed -n -e 's/^.*arguments: //p') \
   ./configure --with-compat $CONFARGS --add-dynamic-module=$NGX_DEVEL_KIT_DIR --add-dynamic-module=$SET_MISC_DIR && \
   make modules
 
-FROM nginx:alpine
+FROM nginx:1.23.3-alpine
 
 # Extract the dynamic modules from the builder image
 COPY --from=builder /usr/src/nginx/nginx-${NGINX_VERSION}/objs/*_module.so /etc/nginx/modules/


### PR DESCRIPTION
Switching from `giggio/docker-image-update-checker` to `lucacome/docker-image-update-checker`. The former is giving false positive results resulting in constant image pushes.

The false positives seems to come from layer `sha256:83e90619bc2e4993eafde3a1f5caf5172010f30ba87bbc5af3d06ed5ed93a9e9` which is present in pulled image, but for some reason not in base image